### PR TITLE
Fix spam using long run patterns.

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -340,6 +340,9 @@ class Game extends ConnectionHandler {
       var vds=['n','s','e','w'];
       for (var r = 0; r < runPat.length; r=r+2) {if (vds.includes(runPat[r+1])==false) {inValidRun();return;}}
       for (var r = 0; r < runPat.length; r=r+2) {if (runPat[r] > 30) {inValidRun();return;}}
+      var runTotal = 0;
+      runPat.filter( o => !isNaN(parseInt(o))).map( o => (runTotal += parseInt(o)));
+      if(runTotal > 20) return inValidRun();
       var diz=this;
       function runTimeout(ri,st){
         setTimeout(function() { 


### PR DESCRIPTION
This pull request will block people from spamming the realm using a long run pattern.
If the total directions of the pattern are over 20, this fix will treat the pattern as invalid, preventing the user from spamming "X enters/leaves from < DIRECTION >" even when offline.

Steps to reproduce:
- Connect and login
- Run a long pattern (`run 1w1w1w1w1w1w1w1w1w1w1w1w1w1w1w.....`)
- Disconnect. The spam will still continue. It's also possible to spam faster by disconnecting and running another long pattern.